### PR TITLE
Added support to Multiple Tint Colors

### DIFF
--- a/CHIPageControl/CHIPageControlAji.swift
+++ b/CHIPageControl/CHIPageControlAji.swift
@@ -68,11 +68,11 @@ open class CHIPageControlAji: CHIBasePageControl {
         active.backgroundColor = (self.currentPageTintColor ?? self.tintColor)?.cgColor
         active.frame = frame
 
-        inactive.forEach() { layer in
-            layer.backgroundColor = self.tintColor.withAlphaComponent(self.inactiveTransparency).cgColor
+        inactive.enumerated().forEach() { index, layer in
+            layer.backgroundColor = self.tintColor(position: index).withAlphaComponent(self.inactiveTransparency).cgColor
             if self.borderWidth > 0 {
                 layer.borderWidth = self.borderWidth
-                layer.borderColor = self.tintColor.cgColor
+                layer.borderColor = self.tintColor(position: index).cgColor
             }
             layer.cornerRadius = self.radius
             layer.frame = frame

--- a/CHIPageControl/CHIPageControlAleppo.swift
+++ b/CHIPageControl/CHIPageControlAleppo.swift
@@ -87,11 +87,11 @@ open class CHIPageControlAleppo: CHIBasePageControl {
         active.backgroundColor = (self.currentPageTintColor ?? self.tintColor)?.cgColor
         active.frame = frame
 
-        inactive.forEach() { layer in
-            layer.backgroundColor = self.tintColor.withAlphaComponent(self.inactiveTransparency).cgColor
+        inactive.enumerated().forEach() { index, layer in
+            layer.backgroundColor = self.tintColor(position: index).withAlphaComponent(self.inactiveTransparency).cgColor
             if self.borderWidth > 0 {
                 layer.borderWidth = self.borderWidth
-                layer.borderColor = self.tintColor.cgColor
+                layer.borderColor = self.tintColor(position: index).cgColor
             }
             layer.cornerRadius = self.radius
             layer.frame = frame

--- a/CHIPageControl/CHIPageControlChimayo.swift
+++ b/CHIPageControl/CHIPageControlChimayo.swift
@@ -67,11 +67,11 @@ open class CHIPageControlChimayo: CHIBasePageControl {
         let y = (self.bounds.size.height - self.diameter)*0.5
         var frame = CGRect(x: x, y: y, width: self.diameter, height: self.diameter)
 
-        inactive.forEach() { layer in
+        inactive.enumerated().forEach() { index, layer in
             layer.cornerRadius = self.radius
             layer.frame = frame
             frame.origin.x += self.diameter + self.padding
-            layer.backgroundColor = self.tintColor.cgColor
+            layer.backgroundColor = self.tintColor(position: index).cgColor
         }
         update(for: progress)
     }

--- a/CHIPageControl/CHIPageControlFresno.swift
+++ b/CHIPageControl/CHIPageControlFresno.swift
@@ -66,11 +66,11 @@ open class CHIPageControlFresno: CHIBasePageControl {
         let y = (self.bounds.size.height - self.diameter)*0.5
         var frame = CGRect(x: x, y: y, width: self.diameter, height: self.diameter)
 
-        elements.forEach() { layer in
-            layer.backgroundColor = self.tintColor.withAlphaComponent(self.inactiveTransparency).cgColor
+        elements.enumerated().forEach() { index, layer in
+            layer.backgroundColor = self.tintColor(position: index).withAlphaComponent(self.inactiveTransparency).cgColor
             if self.borderWidth > 0 {
                 layer.borderWidth = self.borderWidth
-                layer.borderColor = self.tintColor.cgColor
+                layer.borderColor = self.tintColor(position: index).cgColor
             }
             layer.cornerRadius = self.radius
             layer.frame = frame
@@ -127,12 +127,14 @@ open class CHIPageControlFresno: CHIBasePageControl {
         guard frames.indices.contains(index - 1), frames.indices.contains(index) else { return }
 
         let prev = frames[index - 1]
+        let prevColor = tintColor(position: index - 1)
         let current = frames[index]
+        let currentColor = tintColor(position: index)
 
         let elementTotal: CGFloat = current.origin.x - prev.origin.x
         let elementProgress: CGFloat = current.origin.x - active.frame.origin.x
         let elementPercent = (elementTotal - elementProgress) / elementTotal
-
+        
         // x: input, a: input min, b: input max, c: output min, d: output max
         // returns mapped value x from (a,b) to (c, d)
         let linearTransform = { (x: CGFloat, a: CGFloat, b: CGFloat, c: CGFloat, d: CGFloat) -> CGFloat in
@@ -141,6 +143,7 @@ open class CHIPageControlFresno: CHIBasePageControl {
 
         element.frame = prev
         element.frame.origin.x = linearTransform(elementPercent, 1.0, 0.0, prev.origin.x, current.origin.x)
+        element.backgroundColor = blend(color1: currentColor, color2: prevColor, progress: elementPercent).withAlphaComponent(self.inactiveTransparency).cgColor
 
         if elementPercent <= 0.5 {
             let originY = linearTransform(elementPercent, 0.0, 0.5, 0, self.radius + self.padding)

--- a/CHIPageControl/CHIPageControlJalapeno.swift
+++ b/CHIPageControl/CHIPageControlJalapeno.swift
@@ -129,11 +129,11 @@ open class CHIPageControlJalapeno: CHIBasePageControl {
         let y = (self.bounds.size.height - self.diameter)*0.5
         var frame = CGRect(x: x, y: y, width: self.diameter, height: self.diameter)
         
-        inactive.forEach() { layer in
-            layer.backgroundColor = self.tintColor.withAlphaComponent(self.inactiveTransparency).cgColor
+        inactive.enumerated().forEach() { index, layer in
+            layer.backgroundColor = self.tintColor(position: index).withAlphaComponent(self.inactiveTransparency).cgColor
             if self.borderWidth > 0 {
                 layer.borderWidth = self.borderWidth
-                layer.borderColor = self.tintColor.cgColor
+                layer.borderColor = self.tintColor(position: index).cgColor
             }
             layer.cornerRadius = self.radius
             layer.frame = frame

--- a/CHIPageControl/CHIPageControlJaloro.swift
+++ b/CHIPageControl/CHIPageControlJaloro.swift
@@ -77,11 +77,11 @@ open class CHIPageControlJaloro: CHIBasePageControl {
         active.backgroundColor = (self.currentPageTintColor ?? self.tintColor)?.cgColor
         active.frame = frame
 
-        inactive.forEach() { layer in
-            layer.backgroundColor = self.tintColor.withAlphaComponent(self.inactiveTransparency).cgColor
+        inactive.enumerated().forEach() { index, layer in
+            layer.backgroundColor = self.tintColor(position: index).withAlphaComponent(self.inactiveTransparency).cgColor
             if self.borderWidth > 0 {
                 layer.borderWidth = self.borderWidth
-                layer.borderColor = self.tintColor.cgColor
+                layer.borderColor = self.tintColor(position: index).cgColor
             }
             layer.cornerRadius = self.radius
             layer.frame = frame

--- a/CHIPageControl/CHIPageControlPaprika.swift
+++ b/CHIPageControl/CHIPageControlPaprika.swift
@@ -68,11 +68,11 @@ open class CHIPageControlPaprika: CHIBasePageControl {
         let y = (self.bounds.size.height - self.diameter)*0.5
         var frame = CGRect(x: x, y: y, width: self.diameter, height: self.diameter)
         
-        elements.forEach() { layer in
-            layer.backgroundColor = self.tintColor.withAlphaComponent(self.inactiveTransparency).cgColor
+        elements.enumerated().forEach() { index, layer in
+            layer.backgroundColor = self.tintColor(position: index).withAlphaComponent(self.inactiveTransparency).cgColor
             if self.borderWidth > 0 {
                 layer.borderWidth = self.borderWidth
-                layer.borderColor = self.tintColor.cgColor
+                layer.borderColor = self.tintColor(position: index).cgColor
             }
             layer.cornerRadius = self.radius
             layer.frame = frame
@@ -139,9 +139,17 @@ open class CHIPageControlPaprika: CHIBasePageControl {
         guard frames.indices.contains(page), frames.indices.contains(page + 1) else { return }
         
         let prev = frames[page]
+        let prevColor = tintColor(position: page)
         let current = frames[page + 1]
+        let currentColor = tintColor(position: page + 1)
+        
+        let elementTotal: CGFloat = current.origin.x - prev.origin.x
+        let elementProgress: CGFloat = current.origin.x - active.frame.origin.x
+        let elementPercent = (elementTotal - elementProgress) / elementTotal
+        
+        element.borderColor = blend(color1: currentColor, color2: prevColor, progress: elementPercent).cgColor
         element.frame = prev
-        element.frame.origin.x += current.origin.x - active.frame.origin.x
+        element.frame.origin.x += elementProgress
         element.frame.origin.y = 2*min.origin.y - active.frame.origin.y
     }
     

--- a/CHIPageControl/CHIPageControlPuya.swift
+++ b/CHIPageControl/CHIPageControlPuya.swift
@@ -66,11 +66,11 @@ open class CHIPageControlPuya: CHIBasePageControl {
         let y = (self.bounds.size.height - self.diameter)*0.5
         var frame = CGRect(x: x, y: y, width: self.diameter, height: self.diameter)
 
-        elements.forEach() { layer in
-            layer.backgroundColor = self.tintColor.withAlphaComponent(self.inactiveTransparency).cgColor
+        elements.enumerated().forEach() { index, layer in
+            layer.backgroundColor = self.tintColor(position: index).withAlphaComponent(self.inactiveTransparency).cgColor
             if self.borderWidth > 0 {
                 layer.borderWidth = self.borderWidth
-                layer.borderColor = self.tintColor.cgColor
+                layer.borderColor = self.tintColor(position: index).cgColor
             }
             layer.cornerRadius = self.radius
             layer.frame = frame
@@ -121,9 +121,17 @@ open class CHIPageControlPuya: CHIBasePageControl {
         guard frames.indices.contains(page), frames.indices.contains(page + 1) else { return }
 
         let prev = frames[page]
+        let prevColor = tintColor(position: page)
         let current = frames[page + 1]
+        let currentColor = tintColor(position: page + 1)
+        
+        let elementTotal: CGFloat = current.origin.x - prev.origin.x
+        let elementProgress: CGFloat = current.origin.x - active.frame.origin.x
+        let elementPercent = (elementTotal - elementProgress) / elementTotal
+        
+        element.backgroundColor = blend(color1: currentColor, color2: prevColor, progress: elementPercent).withAlphaComponent(self.inactiveTransparency).cgColor
         element.frame = prev
-        element.frame.origin.x += current.origin.x - active.frame.origin.x
+        element.frame.origin.x += elementProgress
     }
 
     override open var intrinsicContentSize: CGSize {

--- a/CHIPageControl/Core/CHIBasePageControl.swift
+++ b/CHIPageControl/Core/CHIBasePageControl.swift
@@ -29,6 +29,7 @@ import UIKit
 
     @IBInspectable open var numberOfPages: Int = 0 {
         didSet {
+            populateTintColors()
             updateNumberOfPages(numberOfPages)
             self.isHidden = hidesForSinglePage && numberOfPages <= 1
         }
@@ -83,6 +84,15 @@ import UIKit
             setNeedsLayout()
         }
     }
+    
+    open var tintColors: [UIColor] = [] {
+        didSet {
+            guard tintColors.count == numberOfPages else {
+                fatalError("The number of tint colors needs to be the same as the number of page")
+            }
+            setNeedsLayout()
+        }
+    }
 
     @IBInspectable open var currentPageTintColor: UIColor? {
         didSet {
@@ -122,6 +132,35 @@ import UIKit
         }
     }
     
+    func tintColor(position: Int) -> UIColor {
+        if tintColors.count < numberOfPages {
+            return tintColor
+        } else {
+            return tintColors[position]
+        }
+    }
+    
+    open func insertTintColor(_ color: UIColor, position: Int) {
+        if tintColors.count < numberOfPages {
+            setupTintColors()
+        }
+        tintColors[position] = color
+    }
+    
+    private func setupTintColors() {
+        tintColors = Array<UIColor>(repeating: tintColor, count: numberOfPages)
+    }
+    
+    private func populateTintColors() {
+        guard tintColors.count > 0 else { return }
+        
+        if tintColors.count > numberOfPages {
+            tintColors = Array(tintColors.prefix(numberOfPages))
+        } else if tintColors.count < numberOfPages {
+            tintColors.append(contentsOf: Array<UIColor>(repeating: tintColor, count: numberOfPages - tintColors.count))
+        }
+    }
+    
     func animate() {
         guard let moveToProgress = self.moveToProgress else { return }
         
@@ -157,5 +196,19 @@ import UIKit
     
     func update(for progress: Double) {
         fatalError("Should be implemented in child class")
+    }
+}
+
+extension CHIBasePageControl {
+    internal func blend(color1: UIColor, color2: UIColor, progress: CGFloat) -> UIColor {
+        let l1 = 1 - progress
+        let l2 = progress
+        var (r1, g1, b1, a1): (CGFloat, CGFloat, CGFloat, CGFloat) = (0, 0, 0, 0)
+        var (r2, g2, b2, a2): (CGFloat, CGFloat, CGFloat, CGFloat) = (0, 0, 0, 0)
+        
+        color1.getRed(&r1, green: &g1, blue: &b1, alpha: &a1)
+        color2.getRed(&r2, green: &g2, blue: &b2, alpha: &a2)
+        
+        return UIColor(red: l1*r1 + l2*r2, green: l1*g1 + l2*g2, blue: l1*b1 + l2*b2, alpha: l1*a1 + l2*a2)
     }
 }

--- a/Example/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -45,7 +46,45 @@
                                     <outlet property="delegate" destination="BYZ-38-t0r" id="FDZ-02-1k7"/>
                                 </connections>
                             </collectionView>
-                            <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nqO-qI-pML" customClass="CHIPageControlAji" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deJ-g4-VW8" userLabel="Colored Page Control Fresno" customClass="CHIPageControlFresno" customModule="CHIPageControl">
+                                <rect key="frame" x="164" y="457" width="47" height="8"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfPages">
+                                        <integer key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="progress">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="padding">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="radius">
+                                        <real key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NOY-UP-9br" userLabel="Colored Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
+                                <rect key="frame" x="164" y="477" width="47" height="8"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfPages">
+                                        <integer key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="progress">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="padding">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="radius">
+                                        <real key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nqO-qI-pML" customClass="CHIPageControlAji" customModule="CHIPageControl">
                                 <rect key="frame" x="163.5" y="643" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -70,7 +109,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nud-cF-PvK" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nud-cF-PvK" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="623" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -89,7 +128,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nFD-kM-D2z" customClass="CHIPageControlAleppo" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nFD-kM-D2z" customClass="CHIPageControlAleppo" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="603" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -114,7 +153,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hO9-ia-7rz" customClass="CHIPageControlChimayo" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hO9-ia-7rz" customClass="CHIPageControlChimayo" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="583" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -133,7 +172,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="563" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -152,7 +191,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b83-NZ-aYL" customClass="CHIPageControlJaloro" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b83-NZ-aYL" customClass="CHIPageControlJaloro" customModule="CHIPageControl">
                                 <rect key="frame" x="156" y="549" width="63" height="2"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -177,7 +216,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AvK-se-ff2" customClass="CHIPageControlPaprika" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AvK-se-ff2" customClass="CHIPageControlPaprika" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="529" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -202,7 +241,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tsb-QT-eRX" customClass="CHIPageControlPuya" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tsb-QT-eRX" customClass="CHIPageControlPuya" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="509" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -231,12 +270,16 @@
                             <constraint firstItem="hO9-ia-7rz" firstAttribute="top" secondItem="2cC-7g-N9D" secondAttribute="bottom" constant="12" id="CKS-2v-8ip"/>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="4cQ-aC-aBf" secondAttribute="bottom" id="EkY-QL-8TU"/>
                             <constraint firstItem="nFD-kM-D2z" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="GNK-4Z-Bki"/>
+                            <constraint firstItem="NOY-UP-9br" firstAttribute="top" secondItem="deJ-g4-VW8" secondAttribute="bottom" constant="12" id="IF2-N6-Vi0"/>
                             <constraint firstItem="4cQ-aC-aBf" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="ILf-qC-VoO"/>
+                            <constraint firstItem="NOY-UP-9br" firstAttribute="centerX" secondItem="4cQ-aC-aBf" secondAttribute="centerX" id="JB6-ep-9LA"/>
                             <constraint firstItem="Nud-cF-PvK" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="JYJ-V8-YUl"/>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="nqO-qI-pML" secondAttribute="bottom" constant="16" id="LdD-3D-QqB"/>
                             <constraint firstItem="nFD-kM-D2z" firstAttribute="top" secondItem="hO9-ia-7rz" secondAttribute="bottom" constant="12" id="OJz-Fu-bDq"/>
+                            <constraint firstItem="deJ-g4-VW8" firstAttribute="centerX" secondItem="4cQ-aC-aBf" secondAttribute="centerX" id="Pl9-Hx-eVe"/>
                             <constraint firstItem="AvK-se-ff2" firstAttribute="top" secondItem="Tsb-QT-eRX" secondAttribute="bottom" constant="12" id="SXi-6F-Ieg"/>
                             <constraint firstItem="4cQ-aC-aBf" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="X8k-yT-Lhx"/>
+                            <constraint firstItem="Tsb-QT-eRX" firstAttribute="top" secondItem="NOY-UP-9br" secondAttribute="bottom" constant="24" id="aGe-en-wFN"/>
                             <constraint firstItem="nqO-qI-pML" firstAttribute="top" secondItem="Nud-cF-PvK" secondAttribute="bottom" constant="12" id="cWJ-TV-cHI"/>
                             <constraint firstItem="Tsb-QT-eRX" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="fXy-EK-L2l"/>
                             <constraint firstAttribute="trailing" secondItem="4cQ-aC-aBf" secondAttribute="trailing" id="g7q-ed-eWs"/>
@@ -255,6 +298,8 @@
                         <outletCollection property="pageControls" destination="Tsb-QT-eRX" collectionClass="NSMutableArray" id="BLi-bv-TBa"/>
                         <outletCollection property="pageControls" destination="AvK-se-ff2" collectionClass="NSMutableArray" id="KD2-fZ-CFB"/>
                         <outletCollection property="pageControls" destination="b83-NZ-aYL" collectionClass="NSMutableArray" id="qGs-iu-W7c"/>
+                        <outletCollection property="coloredPageControls" destination="NOY-UP-9br" collectionClass="NSMutableArray" id="Ux7-3J-El6"/>
+                        <outletCollection property="coloredPageControls" destination="deJ-g4-VW8" collectionClass="NSMutableArray" id="Gbd-E3-MhS"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -13,12 +13,22 @@ class ViewController: UIViewController {
 
     internal let numberOfPages = 4
     @IBOutlet var pageControls: [CHIBasePageControl]!
+    @IBOutlet var coloredPageControls: [CHIBasePageControl]!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.pageControls.forEach { (control) in
             control.numberOfPages = self.numberOfPages
         }
+        
+        // You can insert tint colors to a position (it will replace that position with the selected color)
+        coloredPageControls.forEach { (control) in
+            control.insertTintColor(randomColor(), position: Int(arc4random_uniform(UInt32(numberOfPages))))
+            control.insertTintColor(randomColor(), position: Int(arc4random_uniform(UInt32(numberOfPages))))
+        }
+        
+        // You can also initialize the tintColors with an array
+        coloredPageControls.last?.tintColors = [randomColor(), randomColor(), randomColor(), randomColor()]
     }
 
     func randomColor() -> UIColor{
@@ -56,7 +66,7 @@ extension ViewController: UICollectionViewDelegate, UICollectionViewDataSource, 
         
         let progress = percent * Double(self.numberOfPages - 1)
         
-        self.pageControls.forEach { (control) in
+        (self.pageControls + self.coloredPageControls).forEach { (control) in
             control.progress = progress
         }
     }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ pageControl.tintColor = .red
 pageControl.currentPageTintColor = .green
 pageControl.padding = 6
 ```
+
+### Adding multiple tintColors
+``` swift
+// The size of the array needs to match the numberOfPages or it will throw an fatal error
+pageControl.tintColors = [UIColor.black, UIColor.yellow, UIColor.black, UIColor.black]
+
+// or
+
+// If it is the first one, it will fill all colors with the selected tintColor and then replace the colors with the desired one
+pageControl.insertTintColor(UIColor.yellow, position: 1)
+```
+
 ### Updating progress
 ``` swift
 //update dynamically


### PR DESCRIPTION
I was in need of adding tint colors to different pages, everything works the same way (by using the `tintColor` property) unless you edit the `tintColors` array or `insertTintColor(color:position:)`

Every subclass was updated to support this new feature, they also blend colours when switching places. The active tint color is always the selected (it doesn't change)