### PR TITLE
Enable touch events

### DIFF
--- a/CHIPageControl/CHIPageControlAji.swift
+++ b/CHIPageControl/CHIPageControlAji.swift
@@ -105,4 +105,17 @@ open class CHIPageControlAji: CHIBasePageControl {
         return CGSize(width: CGFloat(inactive.count) * self.diameter + CGFloat(inactive.count - 1) * self.padding,
                       height: self.diameter)
     }
+    
+    override open func didTouch(gesture: UITapGestureRecognizer) {
+        var touchIndex: Int?
+        let point = gesture.location(ofTouch: 0, in: self)
+        inactive.enumerated().forEach({ count, layer in
+            if layer.hitTest(point) != nil {
+                touchIndex = count
+            }
+        })
+        if touchIndex != nil {
+            delegate?.didTouch(pager: self, index: touchIndex!)
+        }
+    }
 }

--- a/CHIPageControl/CHIPageControlAleppo.swift
+++ b/CHIPageControl/CHIPageControlAleppo.swift
@@ -108,4 +108,17 @@ open class CHIPageControlAleppo: CHIBasePageControl {
         return CGSize(width: CGFloat(inactive.count) * self.diameter + CGFloat(inactive.count - 1) * self.padding,
                       height: self.diameter)
     }
+    
+    override open func didTouch(gesture: UITapGestureRecognizer) {
+        var touchIndex: Int?
+        let point = gesture.location(ofTouch: 0, in: self)
+        inactive.enumerated().forEach({ count, layer in
+            if layer.hitTest(point) != nil {
+                touchIndex = count
+            }
+        })
+        if touchIndex != nil {
+            delegate?.didTouch(pager: self, index: touchIndex!)
+        }
+    }
 }

--- a/CHIPageControl/CHIPageControlChimayo.swift
+++ b/CHIPageControl/CHIPageControlChimayo.swift
@@ -105,6 +105,7 @@ open class CHIPageControlChimayo: CHIBasePageControl {
                 bounds.append(UIBezierPath(ovalIn: rect))
             }
             mask.path = bounds.cgPath
+            mask.frame = layer.bounds
             layer.mask = mask
         }
 
@@ -120,5 +121,18 @@ open class CHIPageControlChimayo: CHIBasePageControl {
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
         return CGSize(width: CGFloat(inactive.count) * self.diameter + CGFloat(inactive.count - 1) * self.padding,
                       height: self.diameter)
+    }
+    
+    override open func didTouch(gesture: UITapGestureRecognizer) {
+        var touchIndex: Int?
+        let point = gesture.location(ofTouch: 0, in: self)
+        inactive.enumerated().forEach({ count, layer in
+            if layer.hitTest(point) != nil {
+                touchIndex = count
+            }
+        })
+        if touchIndex != nil {
+            delegate?.didTouch(pager: self, index: touchIndex!)
+        }
     }
 }

--- a/CHIPageControl/CHIPageControlFresno.swift
+++ b/CHIPageControl/CHIPageControlFresno.swift
@@ -32,6 +32,7 @@ open class CHIPageControlFresno: CHIBasePageControl {
     }
 
     fileprivate var elements = [CHILayer]()
+    fileprivate var orderedElements = [CHILayer]()
 
     fileprivate var frames = [CGRect]()
     fileprivate var min: CGRect?
@@ -162,5 +163,26 @@ open class CHIPageControlFresno: CHIBasePageControl {
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
         return CGSize(width: CGFloat(elements.count) * self.diameter + CGFloat(elements.count - 1) * self.padding,
                       height: self.diameter)
+    }
+    
+    override open func didTouch(gesture: UITapGestureRecognizer) {
+        var touchIndex: Int?
+        let point = gesture.location(ofTouch: 0, in: self)
+        elements.enumerated().forEach({ count, layer in
+            if layer.hitTest(point) != nil {
+                touchIndex = count
+            }
+        })
+        if touchIndex != nil {
+            let intProgress = Int(progress)
+            if intProgress > 0 {
+                if touchIndex == 0 {
+                    touchIndex = intProgress
+                } else if touchIndex! <= intProgress {
+                    touchIndex! -= 1
+                }
+            }
+            delegate?.didTouch(pager: self, index: touchIndex!)
+        }
     }
 }

--- a/CHIPageControl/CHIPageControlFresno.swift
+++ b/CHIPageControl/CHIPageControlFresno.swift
@@ -32,7 +32,6 @@ open class CHIPageControlFresno: CHIBasePageControl {
     }
 
     fileprivate var elements = [CHILayer]()
-    fileprivate var orderedElements = [CHILayer]()
 
     fileprivate var frames = [CGRect]()
     fileprivate var min: CGRect?

--- a/CHIPageControl/CHIPageControlJalapeno.swift
+++ b/CHIPageControl/CHIPageControlJalapeno.swift
@@ -151,4 +151,17 @@ open class CHIPageControlJalapeno: CHIBasePageControl {
         return CGSize(width: CGFloat(inactive.count) * self.diameter + CGFloat(inactive.count - 1) * self.padding,
                       height: self.diameter)
     }
+    
+    override open func didTouch(gesture: UITapGestureRecognizer) {
+        var touchIndex: Int?
+        let point = gesture.location(ofTouch: 0, in: self)
+        inactive.enumerated().forEach({ count, layer in
+            if layer.hitTest(point) != nil {
+                touchIndex = count
+            }
+        })
+        if touchIndex != nil {
+            delegate?.didTouch(pager: self, index: touchIndex!)
+        }
+    }
 }

--- a/CHIPageControl/CHIPageControlJaloro.swift
+++ b/CHIPageControl/CHIPageControlJaloro.swift
@@ -116,5 +116,16 @@ open class CHIPageControlJaloro: CHIBasePageControl {
                       height: self.elementHeight)
     }
 
-
+    override open func didTouch(gesture: UITapGestureRecognizer) {
+        var touchIndex: Int?
+        let point = gesture.location(ofTouch: 0, in: self)
+        inactive.enumerated().forEach({ count, layer in
+            if layer.hitTest(point) != nil {
+                touchIndex = count
+            }
+        })
+        if touchIndex != nil {
+            delegate?.didTouch(pager: self, index: touchIndex!)
+        }
+    }
 }

--- a/CHIPageControl/CHIPageControlPaprika.swift
+++ b/CHIPageControl/CHIPageControlPaprika.swift
@@ -161,4 +161,25 @@ open class CHIPageControlPaprika: CHIBasePageControl {
         return CGSize(width: CGFloat(elements.count) * self.diameter + CGFloat(elements.count - 1) * self.padding,
                       height: self.diameter)
     }
+    
+    override open func didTouch(gesture: UITapGestureRecognizer) {
+        var touchIndex: Int?
+        let point = gesture.location(ofTouch: 0, in: self)
+        elements.enumerated().forEach({ count, layer in
+            if layer.hitTest(point) != nil {
+                touchIndex = count
+            }
+        })
+        if touchIndex != nil {
+            let intProgress = Int(progress)
+            if intProgress > 0 {
+                if touchIndex == 0 {
+                    touchIndex = intProgress
+                } else if touchIndex! <= intProgress {
+                    touchIndex! -= 1
+                }
+            }
+            delegate?.didTouch(pager: self, index: touchIndex!)
+        }
+    }
 }

--- a/CHIPageControl/CHIPageControlPuya.swift
+++ b/CHIPageControl/CHIPageControlPuya.swift
@@ -142,4 +142,25 @@ open class CHIPageControlPuya: CHIBasePageControl {
         return CGSize(width: CGFloat(elements.count) * self.diameter + CGFloat(elements.count - 1) * self.padding,
                       height: self.diameter)
     }
+    
+    override open func didTouch(gesture: UITapGestureRecognizer) {
+        var touchIndex: Int?
+        let point = gesture.location(ofTouch: 0, in: self)
+        elements.enumerated().forEach({ count, layer in
+            if layer.hitTest(point) != nil {
+                touchIndex = count
+            }
+        })
+        if touchIndex != nil {
+            let intProgress = Int(progress)
+            if intProgress > 0 {
+                if touchIndex == 0 {
+                    touchIndex = intProgress
+                } else if touchIndex! <= intProgress {
+                    touchIndex! -= 1
+                }
+            }
+            delegate?.didTouch(pager: self, index: touchIndex!)
+        }
+    }
 }

--- a/CHIPageControl/Core/CHIBasePageControl.swift
+++ b/CHIPageControl/Core/CHIBasePageControl.swift
@@ -164,13 +164,19 @@ import UIKit
     }
     
     private var tapEvent: UITapGestureRecognizer?
-    open func enableTouch() {
+    @IBInspectable open var enableTouchEvents: Bool = false {
+        didSet {
+            enableTouchEvents ? enableTouch() : disableTouch()
+        }
+    }
+    
+    private func enableTouch() {
         if tapEvent == nil {
             setupTouchEvent()
         }
     }
     
-    open func disableTouch() {
+    private func disableTouch() {
         if tapEvent != nil {
             removeGestureRecognizer(tapEvent!)
             tapEvent = nil

--- a/CHIPageControl/Core/CHIBasePageControl.swift
+++ b/CHIPageControl/Core/CHIBasePageControl.swift
@@ -26,6 +26,8 @@
 import UIKit
 
 @IBDesignable open class CHIBasePageControl: UIControl, CHIPageControllable {
+    
+    open weak var delegate: CHIBasePageControlDelegate?
 
     @IBInspectable open var numberOfPages: Int = 0 {
         didSet {
@@ -161,6 +163,27 @@ import UIKit
         }
     }
     
+    private var tapEvent: UITapGestureRecognizer?
+    open func enableTouch() {
+        if tapEvent == nil {
+            setupTouchEvent()
+        }
+    }
+    
+    open func disableTouch() {
+        if tapEvent != nil {
+            removeGestureRecognizer(tapEvent!)
+            tapEvent = nil
+        }
+    }
+    
+    internal func setupTouchEvent() {
+        tapEvent = UITapGestureRecognizer(target: self, action: #selector(self.didTouch(gesture:)))
+        addGestureRecognizer(tapEvent!)
+    }
+    
+    internal func didTouch(gesture: UITapGestureRecognizer) {}
+    
     func animate() {
         guard let moveToProgress = self.moveToProgress else { return }
         
@@ -216,6 +239,10 @@ extension CHIBasePageControl {
         
         return UIColor(red: l1*r1 + l2*r2, green: l1*g1 + l2*g2, blue: l1*b1 + l2*b2, alpha: l1*a1 + l2*a2)
     }
+}
+
+public protocol CHIBasePageControlDelegate: class {
+    func didTouch(pager: CHIBasePageControl, index: Int)
 }
 
 final class WeakProxy: NSObject {

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -66,7 +66,7 @@
                                     <outlet property="delegate" destination="BYZ-38-t0r" id="FDZ-02-1k7"/>
                                 </connections>
                             </collectionView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deJ-g4-VW8" userLabel="Colored Page Control Fresno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="deJ-g4-VW8" userLabel="Colored Page Control Fresno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="457" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -83,6 +83,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="radius">
                                         <real key="value" value="4"/>
                                     </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="enableTouchEvents" value="YES"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="H9V-p9-Xqb" userLabel="Vertical Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
@@ -105,7 +106,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NOY-UP-9br" userLabel="Colored Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NOY-UP-9br" userLabel="Colored Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="477" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -124,7 +125,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nqO-qI-pML" customClass="CHIPageControlAji" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nqO-qI-pML" customClass="CHIPageControlAji" customModule="CHIPageControl">
                                 <rect key="frame" x="163.5" y="643" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -149,7 +150,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nud-cF-PvK" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nud-cF-PvK" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="623" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -168,7 +169,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nFD-kM-D2z" customClass="CHIPageControlAleppo" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nFD-kM-D2z" customClass="CHIPageControlAleppo" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="603" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -193,7 +194,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hO9-ia-7rz" customClass="CHIPageControlChimayo" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hO9-ia-7rz" customClass="CHIPageControlChimayo" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="583" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -212,7 +213,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="563" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -231,7 +232,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b83-NZ-aYL" customClass="CHIPageControlJaloro" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b83-NZ-aYL" customClass="CHIPageControlJaloro" customModule="CHIPageControl">
                                 <rect key="frame" x="156" y="549" width="63" height="2"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -256,7 +257,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AvK-se-ff2" customClass="CHIPageControlPaprika" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AvK-se-ff2" customClass="CHIPageControlPaprika" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="529" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -281,7 +282,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tsb-QT-eRX" customClass="CHIPageControlPuya" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tsb-QT-eRX" customClass="CHIPageControlPuya" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="509" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -33,6 +33,14 @@ class ViewController: UIViewController {
 
         //you can display page control vertical
         self.verticalPageControl.transform = self.pageControls.last!.transform.rotated(by: .pi/2)
+        
+        //you can activate touch through code
+        self.verticalPageControl.enableTouchEvents = true
+        self.verticalPageControl.delegate = self
+        
+        self.coloredPageControls.forEach({ pager in
+            pager.delegate = self
+        })
     }
 
     func randomColor() -> UIColor{
@@ -41,6 +49,12 @@ class ViewController: UIViewController {
                        blue: CGFloat(drand48()),
                        alpha: 1.0)
         
+    }
+}
+
+extension ViewController: CHIBasePageControlDelegate {
+    func didTouch(pager: CHIBasePageControl, index: Int) {
+        print(pager, index)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ pageControl.progress = 0.5
 //set progress with animation
 pageControl.set(progress: 2, animated: true)
 ```
+
+### Touch events
+
+You can hear touch events in any of the page indicators. 
+``` swift
+pageControl.enableTouchEvents = true
+```
+
+### Delegate
+
+Implement the `CHIBasePageControlDelegate` to catch touch events.
+
+```swift
+func didTouch(pager: CHIBasePageControl, index: Int)
+```
+
 ### Page Controls 🌶️🌶️🌶️
 
 <img src="Images/Aji.gif" width="100" height="50"> CHIPageControlAji


### PR DESCRIPTION
Enable touch events on any page indicator and delegate method to do whatever the user wants.

Hit area of Jaloro is too small, but still works.