### PR TITLE
Added page control - Sanpedro

### DIFF
--- a/CHIPageControl/CHIPageControlSanpedro.swift
+++ b/CHIPageControl/CHIPageControlSanpedro.swift
@@ -25,9 +25,7 @@
 
 import UIKit
 
-open class CHIPageControlSanpedro: CHIBasePageControl {
-    fileprivate let multScalar = 8.0
-    
+open class CHIPageControlSanpedro: CHIBasePageControl {    
     fileprivate var diameter: CGFloat {
         return radius * 2
     }
@@ -66,16 +64,13 @@ open class CHIPageControlSanpedro: CHIBasePageControl {
         let normalized = progress * Double(diameter + padding)
         let distance = abs(round(progress) - progress)
         
-        print("Normalized : \(normalized)")
-        print("Distance : \(distance)")
-        
-        let mult = 1 + distance * multScalar
-        print("Mult : \(mult)")
+        let mult = 1 - distance
+        let multPadding = 1 - (distance*2)
 
         var frame = active.frame
 
         frame.origin.x = CGFloat(normalized) + firstFrame.origin.x
-        frame.size.width = (frame.height * 2 + padding) * (1/CGFloat(mult))
+        frame.size.width = (frame.height * 2 + (padding * CGFloat(multPadding))) * CGFloat(mult)
         frame.size.height = self.diameter
 
         active.frame = frame

--- a/CHIPageControl/CHIPageControlSanpedro.swift
+++ b/CHIPageControl/CHIPageControlSanpedro.swift
@@ -1,0 +1,123 @@
+//
+//  CHIPageControlSanpedro.swift
+//  CHIPageControl  ( https://github.com/ChiliLabs/CHIPageControl )
+//
+//  Copyright (c) 2019 Peter Suwara
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+open class CHIPageControlSanpedro: CHIBasePageControl {
+    fileprivate let multScalar = 8.0
+    
+    fileprivate var diameter: CGFloat {
+        return radius * 2
+    }
+
+    fileprivate var inactive = [CHILayer]()
+
+    fileprivate var active: CHILayer = CHILayer()
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    override func updateNumberOfPages(_ count: Int) {
+        inactive.forEach { $0.removeFromSuperlayer() }
+        inactive = [CHILayer]()
+        inactive = (0...count).map {_ in
+            let layer = CHILayer()
+            self.layer.addSublayer(layer)
+            return layer
+        }
+        self.layer.addSublayer(active)
+
+        setNeedsLayout()
+        self.invalidateIntrinsicContentSize()
+    }
+
+    override func update(for progress: Double) {
+        guard progress >= 0 && progress <= Double(numberOfPages - 1),
+            let firstFrame = self.inactive.first?.frame,
+            numberOfPages > 1 else { return }
+
+        let normalized = progress * Double(diameter + padding)
+        let distance = abs(round(progress) - progress)
+        
+        print("Normalized : \(normalized)")
+        print("Distance : \(distance)")
+        
+        let mult = 1 + distance * multScalar
+        print("Mult : \(mult)")
+
+        var frame = active.frame
+
+        frame.origin.x = CGFloat(normalized) + firstFrame.origin.x
+        frame.size.width = (frame.height * 2 + padding) * (1/CGFloat(mult))
+        frame.size.height = self.diameter
+
+        active.frame = frame
+    }
+
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        
+        print ("Updating subviews")
+        
+        let floatCount = CGFloat(inactive.count)
+        
+        print ("floatCount : \(floatCount)")
+        let x = (self.bounds.size.width - self.diameter*floatCount - self.padding*(floatCount-1))*0.5
+        let y = (self.bounds.size.height - self.diameter)*0.5
+        print ("X : \(x)")
+        print ("Y : \(y)")
+        var frame = CGRect(x: x, y: y, width: self.diameter, height: self.diameter)
+
+        active.cornerRadius = self.radius
+        active.backgroundColor = (self.currentPageTintColor ?? self.tintColor)?.cgColor
+        active.frame = frame
+
+        inactive.enumerated().forEach() { index, layer in
+            layer.backgroundColor = self.tintColor(position: index).withAlphaComponent(self.inactiveTransparency).cgColor
+            if self.borderWidth > 0 {
+                layer.borderWidth = self.borderWidth
+                layer.borderColor = self.tintColor(position: index).cgColor
+            }
+            layer.cornerRadius = self.radius
+            layer.frame = frame
+            frame.origin.x += self.diameter + self.padding
+        }
+        update(for: progress)
+    }
+
+    override open var intrinsicContentSize: CGSize {
+        return sizeThatFits(CGSize.zero)
+    }
+
+    override open func sizeThatFits(_ size: CGSize) -> CGSize {
+        return CGSize(width: CGFloat(inactive.count) * self.diameter + CGFloat(inactive.count - 1) * self.padding,
+                      height: self.diameter)
+    }
+}

--- a/CHIPageControl/CHIPageControlSanpedro.swift
+++ b/CHIPageControl/CHIPageControlSanpedro.swift
@@ -61,16 +61,18 @@ open class CHIPageControlSanpedro: CHIBasePageControl {
             let firstFrame = self.inactive.first?.frame,
             numberOfPages > 1 else { return }
 
-        let normalized = progress * Double(diameter + padding)
         let distance = abs(round(progress) - progress)
+        let distanceAbs = floor(progress) - progress
+        let distanceClosest = max(0.0, -distanceAbs - 0.5)
         
-        let mult = 1 - distance
-        let multPadding = 1 - (distance*2)
-
+        let segment = (frame.height * 2) + padding
+        
         var frame = active.frame
 
-        frame.origin.x = CGFloat(normalized) + firstFrame.origin.x
-        frame.size.width = (frame.height * 2 + (padding * CGFloat(multPadding))) * CGFloat(mult)
+        frame.origin.x = firstFrame.origin.x +
+            CGFloat(floor(progress) * Double(diameter + padding)) +
+            CGFloat((distanceClosest * 2) * Double(diameter + padding))
+        frame.size.width = segment + ((frame.height + padding) * CGFloat(distance) * 2)
         frame.size.height = self.diameter
 
         active.frame = frame

--- a/CHIPageControl/CHIPageControlSanpedro.swift
+++ b/CHIPageControl/CHIPageControlSanpedro.swift
@@ -78,16 +78,11 @@ open class CHIPageControlSanpedro: CHIBasePageControl {
 
     override open func layoutSubviews() {
         super.layoutSubviews()
-        
-        print ("Updating subviews")
-        
+
         let floatCount = CGFloat(inactive.count)
         
-        print ("floatCount : \(floatCount)")
         let x = (self.bounds.size.width - self.diameter*floatCount - self.padding*(floatCount-1))*0.5
         let y = (self.bounds.size.height - self.diameter)*0.5
-        print ("X : \(x)")
-        print ("Y : \(y)")
         var frame = CGRect(x: x, y: y, width: self.diameter, height: self.diameter)
 
         active.cornerRadius = self.radius

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 				49159E801E76F2760014929B /* Frameworks */,
 				49159E811E76F2760014929B /* Resources */,
 				4B069DEC191367F3D082268D /* [CP] Embed Pods Frameworks */,
-				2D58AE0275121A20B9968B03 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -133,6 +132,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -160,34 +160,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2D58AE0275121A20B9968B03 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		4B069DEC191367F3D082268D /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/CHIPageControl/CHIPageControl.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CHIPageControl.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CA95C1CF53BE35FC132C4E20 /* [CP] Check Pods Manifest.lock */ = {
@@ -196,13 +184,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -341,7 +332,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = lv.chi.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -356,7 +347,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = lv.chi.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    internal func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -67,7 +67,7 @@
                                 </connections>
                             </collectionView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deJ-g4-VW8" userLabel="Colored Page Control Fresno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="437" width="47" height="8"/>
+                                <rect key="frame" x="164" y="433" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -105,7 +105,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NOY-UP-9br" userLabel="Colored Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="457" width="47" height="8"/>
+                                <rect key="frame" x="164" y="453" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -124,7 +124,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nqO-qI-pML" customClass="CHIPageControlAji" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="623" width="47" height="8"/>
+                                <rect key="frame" x="164" y="619" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -149,7 +149,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JKK-8K-EsZ" customClass="CHIPageControlSanpedro" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="643" width="47" height="8"/>
+                                <rect key="frame" x="148.5" y="639" width="78" height="12"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -160,10 +160,10 @@
                                         <real key="value" value="0.0"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="padding">
-                                        <real key="value" value="5"/>
+                                        <real key="value" value="10"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="radius">
-                                        <real key="value" value="4"/>
+                                        <real key="value" value="6"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                         <real key="value" value="1"/>
@@ -174,7 +174,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nud-cF-PvK" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="603" width="47" height="8"/>
+                                <rect key="frame" x="164" y="599" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -193,7 +193,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nFD-kM-D2z" customClass="CHIPageControlAleppo" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="583" width="47" height="8"/>
+                                <rect key="frame" x="164" y="579" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -218,7 +218,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hO9-ia-7rz" customClass="CHIPageControlChimayo" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="563" width="47" height="8"/>
+                                <rect key="frame" x="164" y="559" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -237,7 +237,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="543" width="47" height="8"/>
+                                <rect key="frame" x="164" y="539" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -256,7 +256,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b83-NZ-aYL" customClass="CHIPageControlJaloro" customModule="CHIPageControl">
-                                <rect key="frame" x="156" y="529" width="63" height="2"/>
+                                <rect key="frame" x="156" y="525" width="63" height="2"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -281,7 +281,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AvK-se-ff2" customClass="CHIPageControlPaprika" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="509" width="47" height="8"/>
+                                <rect key="frame" x="164" y="505" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -306,7 +306,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tsb-QT-eRX" customClass="CHIPageControlPuya" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="489" width="47" height="8"/>
+                                <rect key="frame" x="164" y="485" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -370,6 +370,7 @@
                         <outletCollection property="coloredPageControls" destination="NOY-UP-9br" collectionClass="NSMutableArray" id="Ux7-3J-El6"/>
                         <outletCollection property="coloredPageControls" destination="deJ-g4-VW8" collectionClass="NSMutableArray" id="Gbd-E3-MhS"/>
                         <outletCollection property="pageControls" destination="H9V-p9-Xqb" collectionClass="NSMutableArray" id="Oz7-1J-Xyo"/>
+                        <outletCollection property="pageControls" destination="JKK-8K-EsZ" collectionClass="NSMutableArray" id="hRZ-zl-dNq"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -67,7 +67,7 @@
                                 </connections>
                             </collectionView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deJ-g4-VW8" userLabel="Colored Page Control Fresno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="433" width="47" height="8"/>
+                                <rect key="frame" x="164" y="437" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -105,7 +105,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NOY-UP-9br" userLabel="Colored Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="453" width="47" height="8"/>
+                                <rect key="frame" x="164" y="457" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -124,7 +124,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nqO-qI-pML" customClass="CHIPageControlAji" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="619" width="47" height="8"/>
+                                <rect key="frame" x="164" y="623" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -149,7 +149,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JKK-8K-EsZ" customClass="CHIPageControlSanpedro" customModule="CHIPageControl">
-                                <rect key="frame" x="148.5" y="639" width="78" height="12"/>
+                                <rect key="frame" x="157.5" y="643" width="60" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -160,10 +160,10 @@
                                         <real key="value" value="0.0"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="padding">
-                                        <real key="value" value="10"/>
+                                        <integer key="value" value="5"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="radius">
-                                        <real key="value" value="6"/>
+                                        <integer key="value" value="4"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                         <real key="value" value="1"/>
@@ -174,7 +174,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nud-cF-PvK" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="599" width="47" height="8"/>
+                                <rect key="frame" x="164" y="603" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -193,7 +193,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nFD-kM-D2z" customClass="CHIPageControlAleppo" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="579" width="47" height="8"/>
+                                <rect key="frame" x="164" y="583" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -218,7 +218,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hO9-ia-7rz" customClass="CHIPageControlChimayo" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="559" width="47" height="8"/>
+                                <rect key="frame" x="164" y="563" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -237,7 +237,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="539" width="47" height="8"/>
+                                <rect key="frame" x="164" y="543" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -256,7 +256,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b83-NZ-aYL" customClass="CHIPageControlJaloro" customModule="CHIPageControl">
-                                <rect key="frame" x="156" y="525" width="63" height="2"/>
+                                <rect key="frame" x="156" y="529" width="63" height="2"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -281,7 +281,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AvK-se-ff2" customClass="CHIPageControlPaprika" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="505" width="47" height="8"/>
+                                <rect key="frame" x="164" y="509" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -306,7 +306,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tsb-QT-eRX" customClass="CHIPageControlPuya" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="485" width="47" height="8"/>
+                                <rect key="frame" x="164" y="489" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -166,9 +166,6 @@
                                         <integer key="value" value="8"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                        <real key="value" value="1"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="inactiveTransparency">
                                         <real key="value" value="0.0"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -67,7 +67,7 @@
                                 </connections>
                             </collectionView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deJ-g4-VW8" userLabel="Colored Page Control Fresno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="457" width="47" height="8"/>
+                                <rect key="frame" x="164" y="437" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -85,9 +85,8 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="H9V-p9-Xqb" userLabel="Vertical Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H9V-p9-Xqb" userLabel="Vertical Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
                                 <rect key="frame" x="20" y="70" width="47" height="8"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -106,7 +105,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NOY-UP-9br" userLabel="Colored Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="477" width="47" height="8"/>
+                                <rect key="frame" x="164" y="457" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -125,7 +124,32 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nqO-qI-pML" customClass="CHIPageControlAji" customModule="CHIPageControl">
-                                <rect key="frame" x="163.5" y="643" width="47" height="8"/>
+                                <rect key="frame" x="164" y="623" width="47" height="8"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfPages">
+                                        <integer key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="progress">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="padding">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="radius">
+                                        <real key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="inactiveTransparency">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JKK-8K-EsZ" customClass="CHIPageControlSanpedro" customModule="CHIPageControl">
+                                <rect key="frame" x="164" y="643" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -150,7 +174,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nud-cF-PvK" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="623" width="47" height="8"/>
+                                <rect key="frame" x="164" y="603" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -169,7 +193,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nFD-kM-D2z" customClass="CHIPageControlAleppo" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="603" width="47" height="8"/>
+                                <rect key="frame" x="164" y="583" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -194,25 +218,6 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hO9-ia-7rz" customClass="CHIPageControlChimayo" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="583" width="47" height="8"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfPages">
-                                        <integer key="value" value="4"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="progress">
-                                        <real key="value" value="0.0"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="padding">
-                                        <real key="value" value="5"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="radius">
-                                        <real key="value" value="4"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
                                 <rect key="frame" x="164" y="563" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -231,8 +236,27 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
+                                <rect key="frame" x="164" y="543" width="47" height="8"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfPages">
+                                        <integer key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="progress">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="padding">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="radius">
+                                        <real key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b83-NZ-aYL" customClass="CHIPageControlJaloro" customModule="CHIPageControl">
-                                <rect key="frame" x="156" y="549" width="63" height="2"/>
+                                <rect key="frame" x="156" y="529" width="63" height="2"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -257,7 +281,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AvK-se-ff2" customClass="CHIPageControlPaprika" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="529" width="47" height="8"/>
+                                <rect key="frame" x="164" y="509" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -282,7 +306,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tsb-QT-eRX" customClass="CHIPageControlPuya" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="509" width="47" height="8"/>
+                                <rect key="frame" x="164" y="489" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -307,22 +331,26 @@
                             <constraint firstItem="Nud-cF-PvK" firstAttribute="top" secondItem="nFD-kM-D2z" secondAttribute="bottom" constant="12" id="3ll-un-hkH"/>
                             <constraint firstItem="nqO-qI-pML" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="4K2-Ld-AO1"/>
                             <constraint firstItem="2cC-7g-N9D" firstAttribute="top" secondItem="b83-NZ-aYL" secondAttribute="bottom" constant="12" id="9ih-2h-CHi"/>
+                            <constraint firstItem="JKK-8K-EsZ" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="9mA-3s-qla"/>
                             <constraint firstItem="hO9-ia-7rz" firstAttribute="top" secondItem="2cC-7g-N9D" secondAttribute="bottom" constant="12" id="CKS-2v-8ip"/>
+                            <constraint firstItem="H9V-p9-Xqb" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="4" id="EV6-jZ-Bae"/>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="4cQ-aC-aBf" secondAttribute="bottom" id="EkY-QL-8TU"/>
                             <constraint firstItem="nFD-kM-D2z" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="GNK-4Z-Bki"/>
                             <constraint firstItem="NOY-UP-9br" firstAttribute="top" secondItem="deJ-g4-VW8" secondAttribute="bottom" constant="12" id="IF2-N6-Vi0"/>
                             <constraint firstItem="4cQ-aC-aBf" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="ILf-qC-VoO"/>
                             <constraint firstItem="NOY-UP-9br" firstAttribute="centerX" secondItem="4cQ-aC-aBf" secondAttribute="centerX" id="JB6-ep-9LA"/>
                             <constraint firstItem="Nud-cF-PvK" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="JYJ-V8-YUl"/>
-                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="nqO-qI-pML" secondAttribute="bottom" constant="16" id="LdD-3D-QqB"/>
+                            <constraint firstItem="JKK-8K-EsZ" firstAttribute="top" secondItem="nqO-qI-pML" secondAttribute="bottom" constant="12" id="LdD-3D-QqB"/>
                             <constraint firstItem="nFD-kM-D2z" firstAttribute="top" secondItem="hO9-ia-7rz" secondAttribute="bottom" constant="12" id="OJz-Fu-bDq"/>
                             <constraint firstItem="deJ-g4-VW8" firstAttribute="centerX" secondItem="4cQ-aC-aBf" secondAttribute="centerX" id="Pl9-Hx-eVe"/>
                             <constraint firstItem="AvK-se-ff2" firstAttribute="top" secondItem="Tsb-QT-eRX" secondAttribute="bottom" constant="12" id="SXi-6F-Ieg"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="JKK-8K-EsZ" secondAttribute="bottom" constant="16" id="Tv1-uJ-Vu6"/>
                             <constraint firstItem="4cQ-aC-aBf" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="X8k-yT-Lhx"/>
                             <constraint firstItem="Tsb-QT-eRX" firstAttribute="top" secondItem="NOY-UP-9br" secondAttribute="bottom" constant="24" id="aGe-en-wFN"/>
                             <constraint firstItem="nqO-qI-pML" firstAttribute="top" secondItem="Nud-cF-PvK" secondAttribute="bottom" constant="12" id="cWJ-TV-cHI"/>
                             <constraint firstItem="Tsb-QT-eRX" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="fXy-EK-L2l"/>
                             <constraint firstAttribute="trailing" secondItem="4cQ-aC-aBf" secondAttribute="trailing" id="g7q-ed-eWs"/>
+                            <constraint firstItem="H9V-p9-Xqb" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="50" id="rjz-yM-R0p"/>
                             <constraint firstItem="hO9-ia-7rz" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="sYg-cy-IGx"/>
                             <constraint firstItem="b83-NZ-aYL" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="u0R-rM-vAb"/>
                             <constraint firstItem="AvK-se-ff2" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="ypH-k6-MMu"/>

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -67,7 +67,7 @@
                                 </connections>
                             </collectionView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deJ-g4-VW8" userLabel="Colored Page Control Fresno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="437" width="47" height="8"/>
+                                <rect key="frame" x="164" y="429" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -105,7 +105,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NOY-UP-9br" userLabel="Colored Page Control Jalapeno" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="457" width="47" height="8"/>
+                                <rect key="frame" x="164" y="449" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -124,7 +124,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nqO-qI-pML" customClass="CHIPageControlAji" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="623" width="47" height="8"/>
+                                <rect key="frame" x="164" y="615" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -149,7 +149,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JKK-8K-EsZ" customClass="CHIPageControlSanpedro" customModule="CHIPageControl">
-                                <rect key="frame" x="157.5" y="643" width="60" height="8"/>
+                                <rect key="frame" x="127.5" y="635" width="120" height="16"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -160,10 +160,10 @@
                                         <real key="value" value="0.0"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="padding">
-                                        <integer key="value" value="5"/>
+                                        <integer key="value" value="10"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="radius">
-                                        <integer key="value" value="4"/>
+                                        <integer key="value" value="8"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                         <real key="value" value="1"/>
@@ -174,7 +174,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nud-cF-PvK" customClass="CHIPageControlJalapeno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="603" width="47" height="8"/>
+                                <rect key="frame" x="164" y="595" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -193,7 +193,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nFD-kM-D2z" customClass="CHIPageControlAleppo" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="583" width="47" height="8"/>
+                                <rect key="frame" x="164" y="575" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -218,7 +218,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hO9-ia-7rz" customClass="CHIPageControlChimayo" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="563" width="47" height="8"/>
+                                <rect key="frame" x="164" y="555" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -237,7 +237,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2cC-7g-N9D" customClass="CHIPageControlFresno" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="543" width="47" height="8"/>
+                                <rect key="frame" x="164" y="535" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -256,7 +256,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b83-NZ-aYL" customClass="CHIPageControlJaloro" customModule="CHIPageControl">
-                                <rect key="frame" x="156" y="529" width="63" height="2"/>
+                                <rect key="frame" x="156" y="521" width="63" height="2"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -281,7 +281,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AvK-se-ff2" customClass="CHIPageControlPaprika" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="509" width="47" height="8"/>
+                                <rect key="frame" x="164" y="501" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>
@@ -306,7 +306,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tsb-QT-eRX" customClass="CHIPageControlPuya" customModule="CHIPageControl">
-                                <rect key="frame" x="164" y="489" width="47" height="8"/>
+                                <rect key="frame" x="164" y="481" width="47" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <userDefinedRuntimeAttributes>


### PR DESCRIPTION
- New page control added that shows the current page across two dots. 
- When scrolling between dots the frame inverts to a single selection in between the two non-active dots.
- Fixed Example project to support Swift 5 and Xcode 10.3